### PR TITLE
Expose OpenShiftClient's trustCerts configuration.

### DIFF
--- a/src/main/groovy/com/iadams/gradle/openshift/OpenshiftPlugin.groovy
+++ b/src/main/groovy/com/iadams/gradle/openshift/OpenshiftPlugin.groovy
@@ -47,6 +47,7 @@ class OpenshiftPlugin implements Plugin<Project> {
     project.tasks.withType(AbstractOpenshiftTask) {
       conventionMapping.baseUrl = {extension.baseUrl}
       conventionMapping.namespace = {extension.namespace}
+      conventionMapping.trustCerts = {extension.trustCerts}
       conventionMapping.token = {extension.auth.token}
       conventionMapping.username = {extension.auth.username}
       conventionMapping.password = {extension.auth.password}

--- a/src/main/groovy/com/iadams/gradle/openshift/extensions/OpenshiftExtension.groovy
+++ b/src/main/groovy/com/iadams/gradle/openshift/extensions/OpenshiftExtension.groovy
@@ -33,5 +33,5 @@ class OpenshiftExtension {
 
   String namespace
 
-
+  boolean trustCerts
 }

--- a/src/main/groovy/com/iadams/gradle/openshift/tasks/AbstractOpenshiftTask.groovy
+++ b/src/main/groovy/com/iadams/gradle/openshift/tasks/AbstractOpenshiftTask.groovy
@@ -52,6 +52,10 @@ abstract class AbstractOpenshiftTask extends DefaultTask {
   String password
 
   @Input
+  @Optional
+  boolean trustCerts
+
+  @Input
   String namespace
 
   @Internal
@@ -79,6 +83,7 @@ abstract class AbstractOpenshiftTask extends DefaultTask {
     if(getToken()?.trim()){ //if not null or empty
       config = new ConfigBuilder()
           .withMasterUrl(getBaseUrl())
+          .withTrustCerts(isTrustCerts())
           .withNamespace(getNamespace())
           .withOauthToken(getToken())
           .build()
@@ -86,6 +91,7 @@ abstract class AbstractOpenshiftTask extends DefaultTask {
     else {
       config = new ConfigBuilder()
           .withMasterUrl(getBaseUrl())
+          .withTrustCerts(isTrustCerts())
           .withNamespace(getNamespace())
           .withUsername(getUsername())
           .withPassword(getPassword())

--- a/src/test/groovy/com/iadams/gradle/openshift/OpenshiftPluginSpec.groovy
+++ b/src/test/groovy/com/iadams/gradle/openshift/OpenshiftPluginSpec.groovy
@@ -67,12 +67,14 @@ class OpenshiftPluginSpec extends Specification {
     ext.auth.username = 'woot'
     ext.auth.password = 'woot'
     ext.auth.token = 'woot'
+    ext.trustCerts = true
 
     then:
     noExceptionThrown()
     ext.auth.username == 'woot'
     ext.auth.password == 'woot'
     ext.auth.token == 'woot'
+    ext.trustCerts == true
   }
 
   def 'apply does not throw exceptions'() {

--- a/src/test/groovy/com/iadams/gradle/openshift/tasks/AbstractOpenshiftTaskSpec.groovy
+++ b/src/test/groovy/com/iadams/gradle/openshift/tasks/AbstractOpenshiftTaskSpec.groovy
@@ -71,6 +71,23 @@ class AbstractOpenshiftTaskSpec extends Specification {
     t.performLogin()
     t.client.configuration.username == 'developer'
     t.client.configuration.password == 'developer'
+    t.client.configuration.trustCerts == false
+  }
+
+  def "PerformLogin with basic auth and disable cert verification"() {
+    when:
+    Example t = project.tasks.create('example', Example.class)
+    t.namespace = 'my-project'
+    t.username = 'developer'
+    t.password = 'developer'
+    t.baseUrl = "https://my-site:8443"
+    t.trustCerts = true
+
+    then:
+    t.performLogin()
+    t.client.configuration.username == 'developer'
+    t.client.configuration.password == 'developer'
+    t.client.configuration.trustCerts == true
   }
 }
 


### PR DESCRIPTION
Fabric8's impementation of oc's option:
--insecure-skip-tls-verify=false: If true, the server's certificate will not be checked for validity. This will
make your HTTPS connections insecure